### PR TITLE
Add multiline flag to open tasks regex

### DIFF
--- a/github-webhooks/validators/openTasks.js
+++ b/github-webhooks/validators/openTasks.js
@@ -12,7 +12,7 @@ const OpenTaskValidator = function() {
      * @param {string} prBody - Body of the pull request message
      */
     self.validateForOpenTasks = function(prNumber, repoName, commitHash, prBody) {
-        const openTasksLeft = /^[-*]\s\[\s\]/.test(prBody);
+        const openTasksLeft = /^[-*]\s\[\s\]/m.test(prBody);
         if (openTasksLeft)
             self.gitHubClient.setCommitStatus(repoName, commitHash, self.gitHubClient.COMMITSTATUS.FAILURE, 
                 'Some tasks are not checked', 'github-tools/openTasks');


### PR DESCRIPTION
This allows the anchor to match at any newline character instead of just at the beginning of the string.